### PR TITLE
[ocvdemo] removed 2 utf-8_to_latin calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ocvext/build/*
 
 tags
 *.swp
+site/

--- a/ocvdemo/src/ocvdemo-mmi.cc
+++ b/ocvdemo/src/ocvdemo-mmi.cc
@@ -303,7 +303,10 @@ void OCVDemo::maj_langue()
   b_entree.set_tooltip_markup(langue.get_item("entree-tt"));
   b_open.set_tooltip_markup(langue.get_item("entree-tt"));
   // Apparently OpenCV windows support only ISO-8859-1
-  titre_principal = utils::str::utf8_to_latin(langue.get_item("resultats"));
+  // Seems OpenCV does the right thing now.
+  //titre_principal = utils::str::utf8_to_latin(langue.get_item("resultats"));
+  titre_principal = langue.get_item("resultats");
+
   wnd.set_title(langue.get_item("main-title"));
 
   if(langue.current_language != prev_lg)

--- a/ocvdemo/src/ocvdemo.cc
+++ b/ocvdemo/src/ocvdemo.cc
@@ -333,7 +333,9 @@ void OCVDemo::update()
       if(langue.has_item(s))
         s = langue.get_item(s);
     }
-    titres.push_back(utils::str::utf8_to_latin(s)); // à passer en utf-8 dès que fenêtre GTK fait
+//  titres.push_back(utils::str::utf8_to_latin(s)); // à passer en utf-8 dès que fenêtre GTK fait
+    titres.push_back(s); 
+
   }
 
   mosaique.show_multiple_images(titre_principal, lst, titres);
@@ -879,11 +881,13 @@ OCVDemo::OCVDemo(utils::CmdeLine &cmdeline)
     journal.trace_major("Export tableau des fonctions supportees...");
 
     auto s = this->export_html(Localized::Language::LANG_FR);
-    utils::files::save_txt_file("../../../site/contenu/opencv/ocvdemo/table.html", s);
+    utils::files::save_txt_file("../../../site/contenu/opencv/ocvdemo/table-fr.html", s);
     s = this->export_html(Localized::Language::LANG_EN);
     utils::files::save_txt_file("../../../site/contenu/opencv/ocvdemo/table-en.html", s);
     s = this->export_html(Localized::Language::LANG_DE);
     utils::files::save_txt_file("../../../site/contenu/opencv/ocvdemo/table-de.html", s);
+    s = this->export_html(Localized::Language::LANG_RU);
+    utils::files::save_txt_file("../../../site/contenu/opencv/ocvdemo/table-ru.html", s);
 
     if(cmdeline.has_option("-c"))
     {


### PR DESCRIPTION
When in French launguage mode result window has correct label.
Not "R" anymore.
Added writing out the table-ru.html with the -s command line option.
