### PR TITLE
[ocvdemo-mmi.cc] Repair French title of resultats for Linux users.

### DIFF
--- a/ocvdemo/src/ocvdemo-mmi.cc
+++ b/ocvdemo/src/ocvdemo-mmi.cc
@@ -306,8 +306,11 @@ void OCVDemo::maj_langue()
   // Seems OpenCV does the right thing now.
   // Correction. olnly works with OpenCV on Linux. 
   // Still broke on windows.
+#ifdef WIN
   titre_principal = utils::str::utf8_to_latin(langue.get_item("resultats"));
-  //titre_principal = langue.get_item("resultats");
+#else  
+  titre_principal = langue.get_item("resultats");
+#endif
 
   wnd.set_title(langue.get_item("main-title"));
 


### PR DESCRIPTION
Windows users should check to see that they are not effected by this.
