### PR TITLE
Compile fixes for newer versions of opencv

### DIFF
--- a/ocvdemo/Makefile
+++ b/ocvdemo/Makefile
@@ -78,7 +78,7 @@ ADDITIONNAL_TARGETS =
 FIRST_TARGETS =
 
 ifeq ($(TARGET),LINUX)
-ADDITIONNAL_LOPT += ../ocvext/build/ocvext.lib -lopencv_core -lopencv_highgui -lopencv_objdetect -lopencv_features2d -lopencv_stitching -lopencv_imgproc -lopencv_imgcodecs -lopencv_videoio -lopencv_video -lopencv_calib3d -lopencv_photo -lopencv_ml
+ADDITIONNAL_LOPT += ../ocvext/build/ocvext.lib -lopencv_core -lopencv_highgui -lopencv_objdetect -lopencv_features2d -lopencv_stitching -lopencv_imgproc -lopencv_imgcodecs -lopencv_videoio -lopencv_video -lopencv_calib3d -lopencv_photo -lopencv_ml -lopencv_face
 else
 ADDITIONNAL_LOPT += ../ocvext/build/ocvext.lib -mwindows
 ADDITIONNAL_LOPT += -lopencv_core310 -lopencv_imgproc310 -lopencv_highgui310 -lopencv_video310 -lopencv_videoio310 -lopencv_features2d310 -lopencv_objdetect310 -lopencv_imgcodecs310 -lopencv_calib3d310 -lopencv_stitching310 -lopencv_photo310 -lopencv_ml310 -lopencv_face310 -march=i486

--- a/ocvdemo/include/ocvdemo-item.hpp
+++ b/ocvdemo/include/ocvdemo-item.hpp
@@ -70,7 +70,7 @@ public:
   struct OCVDemoItemInput
   {
     /** Modèle (configuration du traitement) */
-    Node model;
+    utils::model::Node model;
 
     /** Si oui, rectangle définissant la ROI */
     cv::Rect roi;

--- a/ocvdemo/include/ocvdemo.hpp
+++ b/ocvdemo/include/ocvdemo.hpp
@@ -116,7 +116,7 @@ private:
   void export_captures(utils::model::Node &cat);
   Mat  get_current_output();
   bool has_output();
-  void setup_demo(const Node &sel);
+  void setup_demo(const utils::model::Node &sel);
   void maj_bts();
   void maj_langue();
   void maj_langue_systeme();

--- a/ocvdemo/src/demo-items/gradient-demo.cc
+++ b/ocvdemo/src/demo-items/gradient-demo.cc
@@ -266,7 +266,7 @@ int HoughDemo::proceed(OCVDemoItemInput &input, OCVDemoItemOutput &output)
     output.nout = 2;
     vector<Vec2f> lines;
     HoughLines(bw, lines, 1, CV_PI/180, seuil, 0, 0);
-    printf("Détecté %d lignes.\n", lines.size());
+    printf("Détecté %zd lignes.\n", lines.size());
     for(size_t i = 0; i < lines.size(); i++ )
     {
       float rho = lines[i][0], theta = lines[i][1];
@@ -305,7 +305,7 @@ int HoughDemo::proceed(OCVDemoItemInput &input, OCVDemoItemOutput &output)
     output.images[0] = I.clone();
     vector<Vec2f> lines;
     HoughLinesWithGradientDir(I, lines, 1, CV_PI/180);
-    printf("Détecté %d lignes.\n", lines.size());
+    printf("Détecté %zd lignes.\n", lines.size());
     for(size_t i = 0; i < lines.size(); i++ )
     {
       float rho = lines[i][0], theta = lines[i][1];
@@ -347,7 +347,7 @@ int HoughCDemo::proceed(OCVDemoItemInput &input, OCVDemoItemOutput &output)
       seuil,
       rmin,
       rmax);
-  printf("Détecté %d cercles.\n", cercles.size());
+  printf("Détecté %zd cercles.\n", cercles.size());
   for(size_t i = 0; i < cercles.size(); i++ )
   {
     float xc = cercles[i][0], yc = cercles[i][1], r = cercles[i][2];

--- a/ocvdemo/src/ocvdemo-mmi.cc
+++ b/ocvdemo/src/ocvdemo-mmi.cc
@@ -247,7 +247,7 @@ void OCVDemo::on_dropped_file(const Glib::RefPtr<Gdk::DragContext>& context, int
 
      journal.trace("DnD: %s.", s.c_str());
 
-     Node new_model = Node::create_ram_node(modele_global.schema());
+     utils::model::Node new_model = utils::model::Node::create_ram_node(modele_global.schema());
      new_model.copy_from(modele_global);
      new_model.set_attribute("sel", 1);
      new_model.set_attribute("file-schema/path", s);

--- a/ocvdemo/src/ocvdemo.cc
+++ b/ocvdemo/src/ocvdemo.cc
@@ -511,7 +511,7 @@ void OCVDemo::maj_entree()
 }
 
 
-void OCVDemo::setup_demo(const Node &sel)
+void OCVDemo::setup_demo(const utils::model::Node &sel)
 {
   auto id = sel.get_attribute_as_string("name");
   auto s = sel.get_localized_name();
@@ -757,7 +757,7 @@ OCVDemo::OCVDemo(utils::CmdeLine &cmdeline)
   }
   else
   {
-    modele_global = Node::create_ram_node(fs_racine->get_schema("global-schema"), chemin_fichier_config);
+    modele_global = utils::model::Node::create_ram_node(fs_racine->get_schema("global-schema"), chemin_fichier_config);
     if(modele_global.is_nullptr())
     {
       modele_global = utils::model::Node::create_ram_node(fs_racine->get_schema("global-schema"));


### PR DESCRIPTION
- directly qualify utils::model::Node to avoid ambiguity
- explicitly link against libopencv_face, looks like it has been factored out into opencv_contrib
- properly "printf" size_t values
